### PR TITLE
Update holy-project.cabal

### DIFF
--- a/holy-project.cabal
+++ b/holy-project.cabal
@@ -41,7 +41,7 @@ source-repository head
 
 executable holy-project
   main-is:              Main.hs
-  -- other-modules:
+  other-modules:        Paths_holy_project
   -- other-extensions:
   build-depends:        base >= 4.6 && < 5
                         , ansi-terminal >= 0.6.1.1
@@ -71,6 +71,7 @@ library
                         , HolyProject.GithubAPI
   other-modules:        HolyProject.GitConfig
                         , HolyProject.MontyPython
+                        , Paths_holy_project
   -- other-modules:
   -- other-extensions:
   build-depends:        base >= 4.6 && < 5
@@ -99,6 +100,7 @@ executable test-holy-project
   main-is:              Test.hs
   other-modules:        HolyProject.GithubAPI.Test
                         , HolyProject.StringUtils.Test
+                        , Paths_holy_project
   default-language:     Haskell2010
   build-depends:        base >=4.6 && < 5
                         , Cabal >= 1.18.0


### PR DESCRIPTION
For issue #2.  Per cabal documentation the Paths_\* modules should be included in `other-modules`.
